### PR TITLE
Adding support for whatever MKDS assembly is, to match feature parity…

### DIFF
--- a/NSMBe5/Patcher/PatchMaker.cs
+++ b/NSMBe5/Patcher/PatchMaker.cs
@@ -186,26 +186,28 @@ namespace NSMBe5.Patcher
                 #endregion
 
                 int ind = -1;
-                if (l.Contains("nsub_"))
-                    ind = l.IndexOf("nsub_");
-                if (l.Contains("hook_"))
-                    ind = l.IndexOf("hook_");
-                if (l.Contains("repl_"))
-                    ind = l.IndexOf("repl_");
-                if (l.Contains("xrpl_"))
-                    ind = l.IndexOf("xrpl_");
-                if (l.Contains("lrpl_"))
-                    ind = l.IndexOf("lrpl_");
+                if (l.Contains("ansub_"))
+                    ind = l.IndexOf("ansub_");
+                if (l.Contains("ahook_"))
+                    ind = l.IndexOf("ahook_");
+                if (l.Contains("arepl_"))
+                    ind = l.IndexOf("arepl_");
+                if (l.Contains("trepl_"))
+                    ind = l.IndexOf("trepl_");
+                if (l.Contains("btrpl_"))
+                    ind = l.IndexOf("btrpl_");
 
                 if (ind != -1)
                 {
                     int destRamAddr= parseHex(l.Substring(0, 8));    //Redirect dest addr
-                    int ramAddr = parseHex(l.Substring(ind + 5, 8)); //Patched addr
+                    String ramAddressPossiblyShort = l.Substring(ind + 6);
+                    if (ramAddressPossiblyShort.Length == 7) ramAddressPossiblyShort = "0" + ramAddressPossiblyShort;
+                    int ramAddr = parseHex(ramAddressPossiblyShort); //Patched addr
                     uint val = 0;
 
                     int ovId = -1;
                     if (l.Contains("_ov_"))
-                        ovId = parseHex(l.Substring(l.IndexOf("_ov_") + 4, 2));
+                        ovId = parseHex(l.Substring(l.IndexOf("_ov_") + 5, 2));
 
                     int patchCategory = 0;
 
@@ -214,22 +216,22 @@ namespace NSMBe5.Patcher
 
                     switch(cmd)
                     {
-                        case "nsub":
+                        case "ansub":
                             val = makeBranchOpcode(ramAddr, destRamAddr, 0);
                             break;
-                        case "repl":
+                        case "arepl":
                             val = makeBranchOpcode(ramAddr, destRamAddr, 1);
                             break;
-                        case "xrpl":
+                        case "trepl":
                             val = makeBranchOpcode(ramAddr, destRamAddr, 2);
                             break;
-                        case "lrpl":
+                        case "btrpl":
                             UInt16 lrvalue = 0xB500; //push {r14}
                             handler.writeToRamAddr(ramAddr, lrvalue, ovId);
                             ramAddr += 2;
                             val = makeBranchOpcode(ramAddr, destRamAddr, 2);
                             break;
-                        case "hook":
+                        case "ahook":
                             //Jump to the hook addr
                             thisHookAddr = hookAddr;
                             val = makeBranchOpcode(ramAddr, hookAddr, 0);
@@ -581,6 +583,9 @@ namespace NSMBe5.Patcher
                     res2 |= (UInt16)((offs << 1)  & 0x7FF);
 
                     res = (uint)(((uint)res2 << 16) | res1);
+
+                } else if (withLink == 3)
+                {
 
                 }
 

--- a/NSMBe5/Properties/AssemblyInfo.cs
+++ b/NSMBe5/Properties/AssemblyInfo.cs
@@ -5,12 +5,12 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("NSMB Editor 5.3")]
+[assembly: AssemblyTitle("NSMB Editor 5.3 | MKDS ASM Mod")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("")]
-[assembly: AssemblyCopyright("Copyright © Treeki and Dirbaio 2019")]
+[assembly: AssemblyCopyright("Copyright © Treeki and Dirbaio 2019, ASM modded by Szymbar 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.1.0.0")]
-[assembly: AssemblyFileVersion("5.1.0.0")]
+[assembly: AssemblyVersion("5.1.1.0")]
+[assembly: AssemblyFileVersion("5.1.1.0")]


### PR DESCRIPTION
… with MKDSCM rendering it obsolete.

All the instructions are using the same structure as the ones we've come up with over the last 8 years of MKDS Assembly history plus some extra ones. I'll build a binary of that xd